### PR TITLE
Add time-windows to the ranged enumeration

### DIFF
--- a/src/main/java/edu/puc/core2/execution/structures/CDS/time/CDSNodeManager.java
+++ b/src/main/java/edu/puc/core2/execution/structures/CDS/time/CDSNodeManager.java
@@ -1,6 +1,7 @@
 package edu.puc.core2.execution.structures.CDS.time;
 
 import edu.puc.core2.parser.plan.cea.Transition;
+import edu.puc.core2.parser.plan.query.TimeWindow;
 import edu.puc.core2.runtime.events.Event;
 
 import java.lang.ref.WeakReference;
@@ -21,17 +22,17 @@ public class CDSNodeManager {
         return newNode;
     }
 
-    public CDSTimeUnionNode createUnionNode(CDSTimeNode left, CDSTimeNode right) {
+    public CDSTimeUnionNode createUnionNode(CDSTimeNode left, CDSTimeNode right, long currentTime, long windowDelta) {
         CDSTimeUnionNode newNode;
         // TODO This is different from the paper...
         if (left.getMax() > right.getMax()) {
-            newNode = new CDSTimeUnionNode(new WeakReference<>(left), new WeakReference<>(right));
+            newNode = new CDSTimeUnionNode(new WeakReference<>(left), new WeakReference<>(right), currentTime, windowDelta);
         } else if (right.getMax() > left.getMax()) {
-            newNode = new CDSTimeUnionNode(new WeakReference<>(right), new WeakReference<>(left));
+            newNode = new CDSTimeUnionNode(new WeakReference<>(right), new WeakReference<>(left), currentTime, windowDelta);
         } else if (left instanceof CDSTimeOutputNode) {
-            newNode = new CDSTimeUnionNode(new WeakReference<>(left), new WeakReference<>(right));
+            newNode = new CDSTimeUnionNode(new WeakReference<>(left), new WeakReference<>(right), currentTime, windowDelta);
         } else if (right instanceof CDSTimeOutputNode) {
-            newNode = new CDSTimeUnionNode(new WeakReference<>(right), new WeakReference<>(left));
+            newNode = new CDSTimeUnionNode(new WeakReference<>(right), new WeakReference<>(left), currentTime, windowDelta);
         } else {
             CDSTimeUnionNode tempLeft = (CDSTimeUnionNode) left;
             CDSTimeUnionNode tempRight = (CDSTimeUnionNode) right;
@@ -44,19 +45,19 @@ public class CDSNodeManager {
             CDSTimeUnionNode u2;
 
             if (tempLeftRight == null) {
-                u2 = new CDSTimeUnionNode(rightRight, leftRight);
+                u2 = new CDSTimeUnionNode(rightRight, leftRight, currentTime, windowDelta);
             } else if (tempRightRight == null) {
-                u2 = new CDSTimeUnionNode(leftRight, rightRight);
+                u2 = new CDSTimeUnionNode(leftRight, rightRight, currentTime, windowDelta);
             } else if (tempLeftRight.getMax() > tempRightRight.getMax()) {
-                u2 = new CDSTimeUnionNode(leftRight, rightRight);
+                u2 = new CDSTimeUnionNode(leftRight, rightRight, currentTime, windowDelta);
             } else {
-                u2 = new CDSTimeUnionNode(rightRight, leftRight);
+                u2 = new CDSTimeUnionNode(rightRight, leftRight, currentTime, windowDelta);
             }
 
             NodeList.add(new LinkedNode(u2));
-            CDSTimeUnionNode u1 = new CDSTimeUnionNode(tempRight.getLeftReference(), new WeakReference<>(u2));
+            CDSTimeUnionNode u1 = new CDSTimeUnionNode(tempRight.getLeftReference(), new WeakReference<>(u2), currentTime, windowDelta);
             NodeList.add(new LinkedNode(u1));
-            newNode = new CDSTimeUnionNode(tempLeft.getLeftReference(), new WeakReference<>(u1));
+            newNode = new CDSTimeUnionNode(tempLeft.getLeftReference(), new WeakReference<>(u1), currentTime, windowDelta);
         }
         NodeList.add(new LinkedNode(newNode));
         return newNode;

--- a/src/main/java/edu/puc/core2/execution/structures/CDS/time/CDSTimeBottomNode.java
+++ b/src/main/java/edu/puc/core2/execution/structures/CDS/time/CDSTimeBottomNode.java
@@ -1,15 +1,26 @@
 package edu.puc.core2.execution.structures.CDS.time;
 
+import java.util.HashMap;
+
 public class CDSTimeBottomNode extends CDSTimeNode {
 
     private final long max;
 
+    private final HashMap<Long, Integer> paths;
+
     // Use with care since the current time is always wrong!
-    public static final CDSTimeBottomNode BOTTOM = new CDSTimeBottomNode(0);
+    public static final CDSTimeBottomNode BOTTOM = new CDSTimeBottomNode(0, null);
+
+    CDSTimeBottomNode(long currentTime, HashMap<Long, Integer> paths) {
+        this.max = currentTime;
+        this.paths = paths;
+    }
 
     /** Use {@link CDSNodeManager} to create CDSTimeNodes. */
     CDSTimeBottomNode(long currentTime) {
         this.max = currentTime;
+        this.paths = new HashMap<>(1);
+        this.paths.put(currentTime, 1);
     }
 
     @Override
@@ -23,8 +34,13 @@ public class CDSTimeBottomNode extends CDSTimeNode {
     }
 
     @Override
-    public int getPaths() {
-        return 1;
+    protected HashMap<Long, Integer> getPaths() {
+        return this.paths;
+    }
+
+    @Override
+    public int getPathsCount(long currentTime, long windowDelta) {
+        return (this.max > currentTime - windowDelta ? 1 : 0);
     }
 }
 

--- a/src/main/java/edu/puc/core2/execution/structures/CDS/time/CDSTimeNode.java
+++ b/src/main/java/edu/puc/core2/execution/structures/CDS/time/CDSTimeNode.java
@@ -1,5 +1,7 @@
 package edu.puc.core2.execution.structures.CDS.time;
 
+import java.util.HashMap;
+
 public abstract class CDSTimeNode {
 
     abstract public boolean isBottom();
@@ -9,6 +11,13 @@ public abstract class CDSTimeNode {
      */
     abstract public long getMax();
 
-    /** The number of paths from this node */
-    abstract public int getPaths();
+    /**
+     * Descending-paths binary relation.
+     */
+    abstract protected HashMap<Long, Integer> getPaths();
+
+    /**
+     * Descending-paths count.
+     * */
+    abstract public int getPathsCount(long currentTime, long windowDelta);
 }

--- a/src/main/java/edu/puc/core2/execution/structures/unionlist/UnionList.java
+++ b/src/main/java/edu/puc/core2/execution/structures/unionlist/UnionList.java
@@ -36,7 +36,7 @@ public class UnionList {
         if (nodeList.isEmpty()) {
             nodeList.add(newNode);
         } else {
-            for (int i = nodeList.size() - 2; i >= 0; i--) {
+            for (int i = nodeList.size() - 1; i > 0; i--) {
                 CDSTimeNode current = nodeList.get(i);
                 if (newNode.getMax() == current.getMax()) {
                     // Order of createUnionNode doesn't matter.

--- a/src/main/java/edu/puc/core2/execution/structures/unionlist/UnionList.java
+++ b/src/main/java/edu/puc/core2/execution/structures/unionlist/UnionList.java
@@ -16,23 +16,23 @@ public class UnionList {
         this.manager = manager;
     }
 
-    public CDSTimeNode merge() {
+    public CDSTimeNode merge(long currentTime, long windowDelta) {
         if (nodeList.isEmpty()) {
             return null;
         } else if (nodeList.size() == 1) {
             return nodeList.get(0);
         } else if (nodeList.size() == 2) {
-            return manager.createUnionNode(nodeList.get(1), nodeList.get(0));
+            return manager.createUnionNode(nodeList.get(1), nodeList.get(0), currentTime, windowDelta);
         } else {
-            CDSTimeUnionNode last = manager.createUnionNode(nodeList.get(1), nodeList.get(0));
+            CDSTimeUnionNode last = manager.createUnionNode(nodeList.get(1), nodeList.get(0), currentTime, windowDelta);
             for (int i = 2; i < nodeList.size(); i++) {
-                last = manager.createUnionNode(nodeList.get(i), last);
+                last = manager.createUnionNode(nodeList.get(i), last, currentTime, windowDelta);
             }
             return last;
         }
     }
 
-    public void insert(CDSTimeNode newNode) {
+    public void insert(CDSTimeNode newNode, long currentTime, long windowDelta) {
         if (nodeList.isEmpty()) {
             nodeList.add(newNode);
         } else {
@@ -40,7 +40,7 @@ public class UnionList {
                 CDSTimeNode current = nodeList.get(i);
                 if (newNode.getMax() == current.getMax()) {
                     // Order of createUnionNode doesn't matter.
-                    nodeList.set(i, manager.createUnionNode(newNode, current));
+                    nodeList.set(i, manager.createUnionNode(newNode, current, currentTime, windowDelta));
                     return;
                 } else if (newNode.getMax() > current.getMax()) {
                     nodeList.add(i, newNode); // shifts to the right

--- a/src/test/java/edu/puc/core2/execution/structures/output/CDSTimeComplexEventGroupingTest.java
+++ b/src/test/java/edu/puc/core2/execution/structures/output/CDSTimeComplexEventGroupingTest.java
@@ -26,7 +26,7 @@ public class CDSTimeComplexEventGroupingTest {
     private static final Event event4 = new Event(4);
     private static final Event event5 = new Event(5);
 
-    private static final long ignoreWindowDelta = Long.MAX_VALUE;
+    private static final long ignoreWindowDelta = 10000L;
     private static final long ignoreCurrentTime = -1;
 
     @BeforeClass
@@ -54,8 +54,8 @@ public class CDSTimeComplexEventGroupingTest {
         CDSTimeNode one = m.createOutputNode(zero, Transition.TransitionType.BLACK, event1, 1);
         CDSTimeNode two = m.createOutputNode(one, Transition.TransitionType.BLACK, event2, 2);
         CDSTimeNode two2 = m.createOutputNode(zero, Transition.TransitionType.BLACK, event2, 2);
-        CDSTimeNode v1 = m.createUnionNode(two2, one);
-        CDSTimeNode v2 = m.createUnionNode(two, v1);
+        CDSTimeNode v1 = m.createUnionNode(two2, one, 3, ignoreWindowDelta);
+        CDSTimeNode v2 = m.createUnionNode(two, v1, 3, ignoreWindowDelta);
         CDSTimeNode three = m.createOutputNode(v2, Transition.TransitionType.BLACK, event3, 3);
 
         ComplexEvent complexEvent1 = new ComplexEvent();
@@ -115,12 +115,12 @@ public class CDSTimeComplexEventGroupingTest {
         CDSTimeNode one = m.createOutputNode(zero, Transition.TransitionType.BLACK, event1, 1);
         CDSTimeNode two = m.createOutputNode(one, Transition.TransitionType.BLACK, event2, 2);
         CDSTimeNode two2 = m.createOutputNode(zero, Transition.TransitionType.BLACK, event2, 2);
-        CDSTimeNode v1 = m.createUnionNode(two, one);
-        CDSTimeNode v2 = m.createUnionNode(two2, v1);
+        CDSTimeNode v1 = m.createUnionNode(two, one, 3, ignoreWindowDelta);
+        CDSTimeNode v2 = m.createUnionNode(two2, v1, 3, ignoreWindowDelta);
         CDSTimeNode three = m.createOutputNode(v2, Transition.TransitionType.BLACK, event3, 3);
         CDSTimeNode three2 = m.createOutputNode(zero, Transition.TransitionType.BLACK, event3, 3);
-        CDSTimeNode v3 = m.createUnionNode(three, v2);
-        CDSTimeNode v4 = m.createUnionNode(three2, v3);
+        CDSTimeNode v3 = m.createUnionNode(three, v2, 4, ignoreWindowDelta);
+        CDSTimeNode v4 = m.createUnionNode(three2, v3, 4, ignoreWindowDelta);
         CDSTimeNode four = m.createOutputNode(v4, Transition.TransitionType.BLACK, event4, 4);
         CDSTimeNode four2 = m.createOutputNode(zero, Transition.TransitionType.BLACK, event4, 4);
 
@@ -332,6 +332,8 @@ public class CDSTimeComplexEventGroupingTest {
        b (0)
     */
     public static Triple<CDSTimeNode, List<ComplexEvent>, Long> getCDSTime1() {
+        long timeWindow = 3;
+
         CDSNodeManager m = new CDSNodeManager();
         CDSTimeNode bottom0 = m.createBottomNode(0);
         CDSTimeNode zero = m.createOutputNode(bottom0, Transition.TransitionType.BLACK, event0, 0);
@@ -340,10 +342,9 @@ public class CDSTimeComplexEventGroupingTest {
         CDSTimeNode bottom1 = m.createBottomNode(1);
         CDSTimeNode oneR = m.createOutputNode(bottom1, Transition.TransitionType.BLACK, event1, 1);
         CDSTimeNode twoR = m.createOutputNode(oneR, Transition.TransitionType.BLACK, event2, 2);
-        CDSTimeNode v = m.createUnionNode(twoR, twoL);
+        CDSTimeNode v = m.createUnionNode(twoR, twoL, 3, timeWindow);
         CDSTimeNode three = m.createOutputNode(v, Transition.TransitionType.BLACK, event3, 3);
 
-        long timeWindow = 2;
         // Notice CE {0,1,2,3} is discarded by the time-windows.
         ComplexEvent complexEvent = new ComplexEvent();
         complexEvent.push(event3, null);
@@ -373,19 +374,19 @@ public class CDSTimeComplexEventGroupingTest {
                   |
                 _ V3
               /   | (l)
-             3   /
-             |   4
-         ___ V1  |
-        / (l)|   V2
-       2     2  /| (l)
-       |     | / 3
-       1     1   |
-       |     |   b (3)
+             3    |
+             |    4
+         ___ V1   |
+        / (l)|    V2
+       2     2   /| (l)
+       |     | /  3
+       1     1    |
+       |     |    b (3)
        0     b (1)
        |
        b (0)
     */
-    public static List<Triple<CDSTimeNode, List<ComplexEvent>, Long>> getCDSTime2() {
+    public static CDSTimeNode getCDSTime2Aux(long timeWindow) {
         CDSNodeManager m = new CDSNodeManager();
         CDSTimeNode bottom0 = m.createBottomNode(0);
         CDSTimeNode bottom1 = m.createBottomNode(1);
@@ -396,18 +397,22 @@ public class CDSTimeComplexEventGroupingTest {
         CDSTimeNode twoL = m.createOutputNode(oneL, Transition.TransitionType.BLACK, event2, 2);
         CDSTimeNode oneR = m.createOutputNode(bottom1, Transition.TransitionType.BLACK, event1, 1);
         CDSTimeNode twoR = m.createOutputNode(oneR, Transition.TransitionType.BLACK, event2, 2);
-        CDSTimeNode v1 = m.createUnionNode(twoR, twoL);
+        CDSTimeNode v1 = m.createUnionNode(twoR, twoL, 3, timeWindow);
         CDSTimeNode threeL = m.createOutputNode(v1, Transition.TransitionType.BLACK, event3, 3);
         CDSTimeNode threeR = m.createOutputNode(bottom3, Transition.TransitionType.BLACK, event3, 3);
-        CDSTimeNode v2 = m.createUnionNode(threeR, oneR);
+        CDSTimeNode v2 = m.createUnionNode(threeR, oneR, 4, timeWindow);
         CDSTimeNode four = m.createOutputNode(v2, Transition.TransitionType.BLACK, event4, 4);
-        CDSTimeNode v3 = m.createUnionNode(four, threeL);
+        CDSTimeNode v3 = m.createUnionNode(four, threeL, 5, timeWindow);
         CDSTimeNode five = m.createOutputNode(v3, Transition.TransitionType.BLACK, event5, 5);
+        return five;
+    }
 
+    public static List<Triple<CDSTimeNode, List<ComplexEvent>, Long>> getCDSTime2() {
         List<Triple<CDSTimeNode, List<ComplexEvent>, Long>> r = new ArrayList<>();
 
         {
-            long timeWindow = 4;
+            long timeWindow = 6;
+            CDSTimeNode root = getCDSTime2Aux(timeWindow);
             ComplexEvent complexEvent1 = new ComplexEvent();
             complexEvent1.push(event5, null);
             complexEvent1.push(event4, null);
@@ -421,16 +426,42 @@ public class CDSTimeComplexEventGroupingTest {
             complexEvent3.push(event3, null);
             complexEvent3.push(event2, null);
             complexEvent3.push(event1, null);
-            r.add(new Triple<>(five, List.of(complexEvent1, complexEvent2, complexEvent3), timeWindow));
+            ComplexEvent complexEvent4 = new ComplexEvent();
+            complexEvent4.push(event5, null);
+            complexEvent4.push(event3, null);
+            complexEvent4.push(event2, null);
+            complexEvent4.push(event1, null);
+            complexEvent4.push(event0, null);
+            r.add(new Triple<>(root, List.of(complexEvent1, complexEvent2, complexEvent3, complexEvent4), timeWindow));
         }
 
         {
-            long timeWindow = 3;
+            long timeWindow = 5;
+            CDSTimeNode root = getCDSTime2Aux(timeWindow);
             ComplexEvent complexEvent1 = new ComplexEvent();
             complexEvent1.push(event5, null);
             complexEvent1.push(event4, null);
             complexEvent1.push(event3, null);
-            r.add(new Triple<>(five, List.of(complexEvent1), timeWindow));
+            ComplexEvent complexEvent2 = new ComplexEvent();
+            complexEvent2.push(event5, null);
+            complexEvent2.push(event4, null);
+            complexEvent2.push(event1, null);
+            ComplexEvent complexEvent3 = new ComplexEvent();
+            complexEvent3.push(event5, null);
+            complexEvent3.push(event3, null);
+            complexEvent3.push(event2, null);
+            complexEvent3.push(event1, null);
+            r.add(new Triple<>(root, List.of(complexEvent1, complexEvent2, complexEvent3), timeWindow));
+        }
+
+        {
+            long timeWindow = 4;
+            CDSTimeNode root = getCDSTime2Aux(timeWindow);
+            ComplexEvent complexEvent1 = new ComplexEvent();
+            complexEvent1.push(event5, null);
+            complexEvent1.push(event4, null);
+            complexEvent1.push(event3, null);
+            r.add(new Triple<>(root, List.of(complexEvent1), timeWindow));
         }
 
         return r;
@@ -454,5 +485,26 @@ public class CDSTimeComplexEventGroupingTest {
 
     // ************************* Time-Window & Ranged Enumeration ******************************
 
-    // TODO
+    @Test
+    public void testTimeWindowsRangedIterator() {
+        int j = 0;
+        int[][] expectedAmountByProcess = {{2, 4}, {2, 3}, {1,1}};
+        for(Triple<CDSTimeNode, List<ComplexEvent>, Long> triplet : getCDSTime2()) {
+            int processes = 2;
+            List<ComplexEvent> expectedComplexEvents = triplet.b;
+            int i = 0;
+            for(int process : zeroToN(processes)) {
+                CDSTimeComplexEventGrouping complexEventGrouping = new CDSTimeComplexEventGrouping(null, 0, triplet.c, ((CDSTimeOutputNode)triplet.a).getEvent().getIndex(), Optional.of(new DistributionConfiguration(process, processes)));
+                complexEventGrouping.addCDSNode(triplet.a);
+                for(ComplexEvent ce: complexEventGrouping) {
+                    if (ce != null) {
+                        assertEquals("ComplexEvent" + i, expectedComplexEvents.get(i), ce);
+                        ++i;
+                    }
+                }
+                assertEquals("Number of complex events", expectedAmountByProcess[j][process], i);
+            }
+            j++;
+        }
+    }
 }


### PR DESCRIPTION
Previously, paths that were outside the time-windows were taken into consideration on the partitioning which resulted in bad load-balances when time-windows were small. Now, these paths are not taken into the count and the partitioning is always balanced even in the presence of pruned paths.